### PR TITLE
Feat: mypage

### DIFF
--- a/src/Components/MainHeader.js
+++ b/src/Components/MainHeader.js
@@ -7,6 +7,7 @@ import logo from "../img/injiklogo.png";
 import searchicon from "../img/searchicon.png";
 import { isLoggedinAtom, isEmployAtom, keystoreAtom } from "../atoms";
 import { useRecoilValue, useSetRecoilState, useResetRecoilState, useRecoilState} from "recoil";
+import { useCookies } from "react-cookie";
 
 const UlParent = styled.ul`
     list-style: none;
@@ -170,6 +171,7 @@ function MainHeader() {
     const [isEmploy, setIsEmploy] = useRecoilState(isEmployAtom);
     const [keystore, setKeystore] = useRecoilState(keystoreAtom);
     const [search, setSearch] = useState("");
+    const [cookies, setCookie, removeCookie] = useCookies(["access_token"]);
 
     const reload = () => {
         navigate("/");
@@ -209,9 +211,11 @@ function MainHeader() {
     }
 
     const logoutClick = () => {
+        removeCookie("access_token", { path: "/" });
         setIsLogined(false);
         setIsEmploy(false);
         setKeystore("");
+        alert("로그아웃 되었습니다.");
     }
 
     const toVCIssue = () => {

--- a/src/Components/MainHeader.js
+++ b/src/Components/MainHeader.js
@@ -215,6 +215,7 @@ function MainHeader() {
         setIsLogined(false);
         setIsEmploy(false);
         setKeystore("");
+        window.sessionStorage.clear();
         alert("로그아웃 되었습니다.");
     }
 

--- a/src/Routes/MyPage.js
+++ b/src/Routes/MyPage.js
@@ -142,9 +142,11 @@ function MyPage() {
     const [isOpenModal, setOpenModal] = useState(false);
     const [isApplyList, setIsApplyList] = useState(true);
     const [isVCList, setIsVCList] = useState(false);
+    const [claimList, setClaimList] = useState([]);
     const isLoggedin = useRecoilValue(isLoggedinAtom);
     const isEmployee = useRecoilValue(isEmployAtom);
     const navigate = useNavigate();
+    const axios = require("axios");
 
     const onClickToggleModal = useCallback(() => {
         setOpenModal(!isOpenModal);
@@ -155,6 +157,10 @@ function MyPage() {
             alert("로그인이 필요합니다");
             navigate("/Signin");
         }
+        axios.get(`http://${window.location.hostname}:60080/api/v0/claim`)
+        .then(res => {
+            setClaimList(res.data.claims);
+        }).catch(() => {});
     },[]);
 
 
@@ -254,7 +260,7 @@ function MyPage() {
                         <span></span>
                     </SubTitle>
                     <ul>
-                        {EmployerCareerList.claims.map((element, index) => 
+                        {claimList.map((element, index) => 
                         <Item onClick={onClickToggleModal}>
                             <span
                             style={{

--- a/src/Routes/MyPage.js
+++ b/src/Routes/MyPage.js
@@ -143,6 +143,7 @@ function MyPage() {
     const [isApplyList, setIsApplyList] = useState(true);
     const [isVCList, setIsVCList] = useState(false);
     const [claimList, setClaimList] = useState([]);
+    const [resumeList, setResumeList] = useState([]);
     const isLoggedin = useRecoilValue(isLoggedinAtom);
     const isEmployee = useRecoilValue(isEmployAtom);
     const navigate = useNavigate();
@@ -160,6 +161,10 @@ function MyPage() {
         axios.get(`http://${window.location.hostname}:60080/api/v0/claim`)
         .then(res => {
             setClaimList(res.data.claims);
+        }).catch(() => {});
+        axios.get(`http://${window.location.hostname}:60080/api/v0/resume`)
+        .then(res => {
+            setResumeList(res.data.claims);
         }).catch(() => {});
     },[]);
 
@@ -234,7 +239,7 @@ function MyPage() {
                         <span></span>
                     </SubTitle>
                     <ul>
-                        {ResumeList.claims.map((element,index) => 
+                        {resumeList.map((element,index) => 
                         <Item onClick={onClickToggleModal}>
                             <span
                             style={{

--- a/src/Routes/Signin.js
+++ b/src/Routes/Signin.js
@@ -137,10 +137,9 @@ function Signin() {
         }
         data.keystore = JSON.parse(data.keystore);
         const axios = require('axios'); 
-        axios.default.withCredentials = true;   
         const config = {
             method: 'post',
-            url: 'http://localhost:60080/api/v0/user/token',
+            url: `http://${window.location.hostname}:60080/api/v0/user/token`,
             headers: { 
                 'Content-Type': 'application/json',
             },
@@ -150,9 +149,8 @@ function Signin() {
         axios(config)
         .then(function (response) {
             console.log(JSON.stringify(response.data));
-            //console.log(document.cookie)
             setIsLogined(true);
-            // setIsEmploy(data.); keystore로 회원정보 가져와야댐 !!!!!!!!!!!!!!!
+            setIsEmploy(response.data.user.user_type === 1);
             setKeystore(JSON.stringify(data.keystore));
             navigate("/");
         })

--- a/src/Routes/Signin.js
+++ b/src/Routes/Signin.js
@@ -149,9 +149,13 @@ function Signin() {
         axios(config)
         .then(function (response) {
             console.log(JSON.stringify(response.data));
+            const userType = "" + response.data.user.user_type;
+            const keystore = JSON.stringify(data.keystore);
             setIsLogined(true);
-            setIsEmploy(response.data.user.user_type === 1);
-            setKeystore(JSON.stringify(data.keystore));
+            setIsEmploy(userType === "1");
+            setKeystore(keystore);
+            window.sessionStorage.setItem("userType", userType); // Use sessionStorage for storing user type
+            window.sessionStorage.setItem("keystore", keystore); // Use sessionStorage for storing keystore
             navigate("/");
         })
         .catch(function (error) {

--- a/src/Routes/Signup.js
+++ b/src/Routes/Signup.js
@@ -143,7 +143,7 @@ function Signup () {
 
        const config = {
            method: 'post',
-           url: 'http://localhost:60080/api/v0/user',
+           url: 'http://saltwalks.ddns.net:60080/api/v0/user',
            headers: { 
                'Content-Type': 'application/json'
            },

--- a/src/Routes/VCIssue.js
+++ b/src/Routes/VCIssue.js
@@ -100,7 +100,6 @@ function VCIssue() {
         }
         axios.get(`http://${window.location.hostname}:60080/api/v0/user?type=0`)
         .then(res => {
-            console.log(res.data);
             setOption(res.data.users.map(user => ({
                 value: user.did,
                 label: user.display_name,
@@ -116,7 +115,6 @@ function VCIssue() {
     }
 
     const onValid = (data) => {
-        console.log(issuer);
         if(issuer==="") {
             alert("발급처를 선택해주세요");
         } else {

--- a/src/atoms.js
+++ b/src/atoms.js
@@ -8,10 +8,10 @@ export const isLoggedinAtom = atom({
 
 export const isEmployAtom = atom({
     key: "isEmployee",
-    default: false,
+    default: window.sessionStorage.getItem("userType") === "1",
 });
 
 export const keystoreAtom = atom({
   key: "keystore",
-  default: "",
+  default: window.sessionStorage.getItem("keystore") || "",
 });

--- a/src/atoms.js
+++ b/src/atoms.js
@@ -1,8 +1,9 @@
 import { atom } from "recoil";
+import { Cookies } from 'react-cookie';
 
 export const isLoggedinAtom = atom({
   key: "isLoggedin",
-  default: false,
+  default: !!(new Cookies().get("access_token")),
 });
 
 export const isEmployAtom = atom({


### PR DESCRIPTION
## 추가된 기능

- [마이페이지] 경력 요청 리스트 가져오기
- [마이페이지] 이력서 리스트 가져오기
- isEmploy atom recoil 활성화 -> 이제 hook을 통해 구직자인지 구인자인지 가져올 수 있음
    - 따라서 [마이페이지] 에서 왼쪽 메뉴 이름들도 구인 / 구직자에 따라 다르게 나옴
- 새로고침 버그 -> 이제 새로고침해도 로그아웃되지 않고 atom recoil 값들도 사라지지 않음
- 로그아웃 -> 로그아웃시 쿠키를 포함한 모든 것들이 초기화됨

## 변경사항

- Signin.js Signup.js 에서 API URL 변경 -> 하드코딩돼있던거 `window.location.hostname` 으로 자동으로 가져오게 함
- 구인 / 구직자 구별 + 키스토어 sessionStorage 에 저장